### PR TITLE
Fix typo in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install reachable-url --save
 ```js
 ;(async () => {
   const reachableUrl = require('reachable-url')
-  const { url } = await reachableUrl('https://googe.com', { folloRedirects: false })
+  const { url } = await reachableUrl('https://google.com', { followRedirect: false })
 })()
 ```
 


### PR DESCRIPTION
1. The `options` part should be [`followRedirect`](https://github.com/sindresorhus/got#followredirect) instead of `folloRedirects`
2. The URL given in the example is a real site but seems untrustworthy, so I changed it to Google.com