### PR TITLE
feat: avoid body without destroying request

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,17 @@ const { URL } = require('url')
 const got = require('got').extend({
   decompress: false,
   responseType: 'buffer',
-  retry: 0
+  retry: 1,
+  headers: {
+    Range: 'bytes=0-0'
+  },
+  hooks: {
+    beforeRetry: [
+      options => {
+        delete options.headers.range
+      }
+    ]
+  }
 })
 
 const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
@@ -26,7 +36,6 @@ const reachableUrl = async (url, opts) => {
 
   req.on('response', res => {
     response = res
-    response.once('data', () => req.cancel())
   })
 
   req.on('redirect', res => {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@
 
 const pReflect = require('p-reflect')
 const { URL } = require('url')
-const got = require('got')
+
+const got = require('got').extend({
+  decompress: false,
+  responseType: 'buffer',
+  retry: 0
+})
 
 const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
   statusMessage: 'Not Found',
@@ -12,12 +17,8 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
   ...responseDestination
 })
 
-const reachableUrl = async (url, opts = {}) => {
-  const req = got(url, {
-    ...opts,
-    retry: 0,
-    responseType: 'buffer'
-  })
+const reachableUrl = async (url, opts) => {
+  const req = got(url, opts)
 
   const redirectStatusCodes = []
   const redirectUrls = []

--- a/test/cache.js
+++ b/test/cache.js
@@ -8,12 +8,12 @@ test("don't cache response with no cache-control", async t => {
   const url = 'https://test-http.vercel.app/'
   const cache = new Map()
 
-  const responseOne = await reachableUrl(url, { cache })
+  const responseOne = await reachableUrl(url, { cache, timeout: 3000 })
 
   t.is(responseOne.isFromCache, false)
   t.is(cache.size, 1)
 
-  const responseTwo = await reachableUrl(url, { cache })
+  const responseTwo = await reachableUrl(url, { cache, timeout: 3000 })
 
   t.is(responseTwo.isFromCache, false)
   t.is(cache.size, 1)
@@ -38,14 +38,10 @@ test('5xx', async t => {
   const url = 'https://test-http.vercel.app/?statusCode=500&maxAge=300'
   const cache = new Map()
 
-  const responseOne = await reachableUrl(url, { cache })
+  await reachableUrl(url, { cache, timeout: 3000 })
+  const response = await reachableUrl(url, { cache, timeout: 3000 })
 
-  t.is(responseOne.isFromCache, false)
-  t.is(cache.size, 1)
-
-  const responseTwo = await reachableUrl(url, { cache })
-
-  t.is(responseTwo.isFromCache, true)
+  t.is(response.isFromCache, true)
   t.is(cache.size, 1)
 })
 
@@ -68,19 +64,19 @@ test('2xx', async t => {
   const url = 'https://test-http.vercel.app/?maxAge=300'
   const cache = new Map()
 
-  const responseOne = await reachableUrl(url, { cache })
+  const responseOne = await reachableUrl(url, { cache, timeout: 3000 })
 
   t.is(responseOne.isFromCache, false)
   t.is(cache.size, 1)
 
-  const responseTwo = await reachableUrl(url, { cache })
+  const responseTwo = await reachableUrl(url, { cache, timeout: 3000 })
 
   t.is(responseTwo.isFromCache, true)
   t.is(cache.size, 1)
 })
 
 test('static asset', async t => {
-  const url = 'https://microlink.io/favicon.ico'
+  const url = 'http://ftp.nluug.nl/pub/graphics/blender/demo/movies/ToS/ToS-4k-1920.mov'
   const cache = new Map()
 
   const responseOne = await reachableUrl(url, { cache })

--- a/test/index.js
+++ b/test/index.js
@@ -59,7 +59,6 @@ test('resolve multiple redirects', async t => {
   ])
   t.deepEqual(res.redirectStatusCodes, [302, 302, 302])
   t.is('https://example.com/', res.url)
-  t.is(200, res.statusCode)
   t.true(isReachable(res))
 })
 
@@ -112,10 +111,10 @@ test('keep original query search', async t => {
     'https://www.b92.net/biz/vesti/srbija/dogovoreno-nikola-tesla-primer-aerodromu-u-cg-1465369'
   const res = await reachableUrl(url)
   t.is(res.url, url)
-  t.is(200, res.statusCode)
-  t.is(res.statusMessage, 'OK')
-  t.true(Object.keys(res.headers).length > 0)
   t.true(isReachable(res))
+  t.true(Object.keys(res.headers).length > 0)
+  t.truthy(res.headers['content-length'])
+  t.truthy(res.headers['content-range'])
 })
 
 test("ensure to don't download body", async t => {
@@ -123,9 +122,10 @@ test("ensure to don't download body", async t => {
   const url = 'http://ftp.nluug.nl/pub/graphics/blender/demo/movies/ToS/ToS-4k-1920.mov'
   const res = await reachableUrl(url)
   t.is(res.url, url)
-  t.is(200, res.statusCode)
-  t.is(res.statusMessage, 'OK')
+  t.true(isReachable(res))
   t.true(Object.keys(res.headers).length > 0)
+  t.truthy(res.headers['content-length'])
+  t.truthy(res.headers['content-range'])
 })
 
 test('handle DNS errors', async t => {
@@ -157,15 +157,13 @@ test('fast unreachable request resolution', async t => {
   const url = 'https://httpbin.org/status/404'
   const res = await reachableUrl(url)
   t.is(res.url, url)
-  t.is(res.statusCode, 404)
-  t.is(res.statusMessage.toLowerCase(), 'not found')
+  t.false(isReachable(res))
 })
 
 test('header `content-length` is present', async t => {
   const url = 'https://cdn-microlink.vercel.app/file-examples/file_example_CSV_5000.csv'
   const res = await reachableUrl(url)
   t.is(res.url, url)
-  t.is(200, res.statusCode)
-  t.is(res.statusMessage, 'OK')
+  t.true(isReachable(res))
   t.truthy(res.headers['content-length'])
 })

--- a/test/index.js
+++ b/test/index.js
@@ -160,3 +160,12 @@ test('fast unreachable request resolution', async t => {
   t.is(res.statusCode, 404)
   t.is(res.statusMessage.toLowerCase(), 'not found')
 })
+
+test('header `content-length` is present', async t => {
+  const url = 'https://cdn-microlink.vercel.app/file-examples/file_example_CSV_5000.csv'
+  const res = await reachableUrl(url)
+  t.is(res.url, url)
+  t.is(200, res.statusCode)
+  t.is(res.statusMessage, 'OK')
+  t.truthy(res.headers['content-length'])
+})


### PR DESCRIPTION
The current source code implementation is aborting response body after the first chunk is received:

```js
req.on('response', res => {
    response = res
    response.once('data', () => req.cancel())
  })
```

This is a very tricky way to avoid resolving the request body, and it will cause some undesirable behavior since the request was aborted abruptly.

Instead, we can setup [range](https://developer.mozilla.org/en-US/docs/Web/API/Range) header to request the minimal quantity of body bytes. Could be possible the server doesn't support range requests, so we need to enable retry.

Perform a HEAD request is discarded since most of the servers disallow them.
