### PR TITLE
fix!: treat an unfollowed redirect as unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ The target URL to be resolved.
 
 Same as [got#options](https://github.com/sindresorhus/got#goturl-options)
 
+The resolved response echoes back `followRedirect`, so it can be handed straight to `reachableUrl.isReachable`.
+
+### reachableUrl.isReachable(response)
+
+#### response
+
+*Required*<br>
+Type: `object`
+
+The response returned by `reachableUrl`. Only `statusCode` and `followRedirect` are read.
+
+A URL is reachable when the response is a final 2xx.
+
+A redirect status is the final answer only when redirects were not being followed:
+
+```js
+const response = await reachableUrl('https://example.com', { followRedirect: false })
+reachableUrl.isReachable(response) // => true, the 3xx is the destination
+```
+
+With redirect following on (the default), a 3xx is the hop the follow stopped at (a `beforeRedirect` hook threw, `maxRedirects` ran out), meaning the URL was never reached:
+
+```js
+const response = await reachableUrl('https://example.com', {
+  hooks: { beforeRedirect: [() => { throw new Error('refused') }] }
+})
+reachableUrl.isReachable(response) // => false
+```
+
+`followRedirect` defaults to `true`, so a partial `{ statusCode }` object is judged as if redirects were being followed.
+
 ## License
 
 **reachable-url** © [Kiko Beats](https://kikobeats.com), released under the [MIT](https://github.com/Kikobeats/reachable-url/blob/master/LICENSE.md) License.<br>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The target URL to be resolved.
 
 Same as [got#options](https://github.com/sindresorhus/got#goturl-options)
 
-The resolved response echoes back `followRedirect`, so it can be handed straight to `reachableUrl.isReachable`.
-
 ### reachableUrl.isReachable(response)
 
 #### response
@@ -44,7 +42,7 @@ The resolved response echoes back `followRedirect`, so it can be handed straight
 *Required*<br>
 Type: `object`
 
-The response returned by `reachableUrl`. Only `statusCode` and `followRedirect` are read.
+The response returned by `reachableUrl`, which echoes back `followRedirect` so it can be handed straight over.
 
 A URL is reachable when the response is a final 2xx.
 
@@ -64,7 +62,7 @@ const response = await reachableUrl('https://example.com', {
 reachableUrl.isReachable(response) // => false
 ```
 
-`followRedirect` defaults to `true`, so a partial `{ statusCode }` object is judged as if redirects were being followed.
+A partial object missing `followRedirect` is judged as if redirects were being followed, so a bare `{ statusCode: 302 }` is unreachable.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
 })
 
 const reachableUrl = async (url, opts) => {
+  const followRedirect = opts?.followRedirect ?? true
   const req = got(url, opts)
 
   const redirectStatusCodes = []
@@ -64,13 +65,20 @@ const reachableUrl = async (url, opts) => {
   return {
     url,
     ...mergedResponse,
+    followRedirect,
     redirectUrls,
     redirectStatusCodes,
     requestUrl: url
   }
 }
 
-const isReachable = ({ statusCode }) => statusCode >= 200 && statusCode < 400
+const isRedirect = statusCode => statusCode >= 300 && statusCode < 400
+
+// A 3xx is the destination only when redirects were not being followed. With
+// following on, it is the hop the follow stopped at (a `beforeRedirect` hook
+// threw, `maxRedirects` ran out) and the URL was never reached.
+const isReachable = ({ statusCode, followRedirect = true }) =>
+  isRedirect(statusCode) ? !followRedirect : statusCode >= 200 && statusCode < 300
 
 module.exports = async (url, opts) => {
   if (/^\/\//.test(url)) url = `https:${url}`

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
 })
 
 const reachableUrl = async (url, opts) => {
-  const followRedirect = opts?.followRedirect ?? true
+  const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, opts)
 
   const redirectStatusCodes = []
@@ -72,13 +72,9 @@ const reachableUrl = async (url, opts) => {
   }
 }
 
-const isRedirect = statusCode => statusCode >= 300 && statusCode < 400
-
-// A 3xx is the destination only when redirects were not being followed. With
-// following on, it is the hop the follow stopped at (a `beforeRedirect` hook
-// threw, `maxRedirects` ran out) and the URL was never reached.
+// While following, a 3xx is the hop the follow stopped at, never the destination.
 const isReachable = ({ statusCode, followRedirect = true }) =>
-  isRedirect(statusCode) ? !followRedirect : statusCode >= 200 && statusCode < 300
+  statusCode >= 200 && statusCode < (followRedirect ? 300 : 400)
 
 module.exports = async (url, opts) => {
   if (/^\/\//.test(url)) url = `https:${url}`

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,65 @@ test('passing options', async t => {
   t.true(isReachable(res))
 })
 
+const createRedirectServer = async (t, location = 'https://example.com') => {
+  const server = createServer((req, res) => {
+    res.writeHead(302, { location })
+    res.end()
+  })
+  t.teardown(() => closeServer(server))
+  return listen(server, { port: 0, host: '127.0.0.1' })
+}
+
+test('a redirect refused before connecting is not reachable', async t => {
+  const url = await createRedirectServer(t)
+
+  const res = await reachableUrl(url, {
+    hooks: {
+      beforeRedirect: [
+        () => {
+          throw new Error('Refusing to request a reserved address')
+        }
+      ]
+    }
+  })
+
+  t.is(res.statusCode, 302)
+  t.true(res.followRedirect)
+  t.false(isReachable(res))
+})
+
+test('running out of redirects is not reachable', async t => {
+  const server = createServer((req, res) => {
+    res.writeHead(302, { location: req.url === '/' ? '/next' : '/' })
+    res.end()
+  })
+  t.teardown(() => closeServer(server))
+  const url = await listen(server, { port: 0, host: '127.0.0.1' })
+
+  const res = await reachableUrl(url, { maxRedirects: 1 })
+
+  t.is(res.statusCode, 302)
+  t.false(isReachable(res))
+})
+
+test('a redirect is the destination when redirects are not followed', async t => {
+  const url = await createRedirectServer(t)
+
+  const res = await reachableUrl(url, { followRedirect: false })
+
+  t.is(res.statusCode, 302)
+  t.false(res.followRedirect)
+  t.true(isReachable(res))
+})
+
+test('isReachable treats a bare redirect status as unfinished', t => {
+  t.true(isReachable({ statusCode: 200 }))
+  t.false(isReachable({ statusCode: 404 }))
+  t.false(isReachable({ statusCode: 302 }))
+  t.false(isReachable({ statusCode: 302, followRedirect: true }))
+  t.true(isReachable({ statusCode: 302, followRedirect: false }))
+})
+
 test('resolve non encoding urls', async t => {
   const origin = await createEchoServer(t)
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,12 @@ const { URL } = require('url')
 const test = require('ava').default
 const got = require('got')
 
-const { createEchoServer, createStatusServer, createRangeServer } = require('./_helpers')
+const {
+  createTestServer,
+  createEchoServer,
+  createStatusServer,
+  createRangeServer
+} = require('./_helpers')
 
 const reachableUrl = require('..')
 
@@ -71,14 +76,11 @@ test('passing options', async t => {
   t.true(isReachable(res))
 })
 
-const createRedirectServer = async (t, location = 'https://example.com') => {
-  const server = createServer((req, res) => {
-    res.writeHead(302, { location })
+const createRedirectServer = (t, location = () => 'https://example.com') =>
+  createTestServer(t, (req, res) => {
+    res.writeHead(302, { location: location(req) })
     res.end()
   })
-  t.teardown(() => closeServer(server))
-  return listen(server, { port: 0, host: '127.0.0.1' })
-}
 
 test('a redirect refused before connecting is not reachable', async t => {
   const url = await createRedirectServer(t)
@@ -99,12 +101,7 @@ test('a redirect refused before connecting is not reachable', async t => {
 })
 
 test('running out of redirects is not reachable', async t => {
-  const server = createServer((req, res) => {
-    res.writeHead(302, { location: req.url === '/' ? '/next' : '/' })
-    res.end()
-  })
-  t.teardown(() => closeServer(server))
-  const url = await listen(server, { port: 0, host: '127.0.0.1' })
+  const url = await createRedirectServer(t, req => (req.url === '/' ? '/next' : '/'))
 
   const res = await reachableUrl(url, { maxRedirects: 1 })
 
@@ -126,7 +123,6 @@ test('isReachable treats a bare redirect status as unfinished', t => {
   t.true(isReachable({ statusCode: 200 }))
   t.false(isReachable({ statusCode: 404 }))
   t.false(isReachable({ statusCode: 302 }))
-  t.false(isReachable({ statusCode: 302, followRedirect: true }))
   t.true(isReachable({ statusCode: 302, followRedirect: false }))
 })
 


### PR DESCRIPTION
## Bug

`isReachable` accepted any 3xx:

```js
const isReachable = ({ statusCode }) => statusCode >= 200 && statusCode < 400
```

With redirect following on (got's default) a 3xx is never the destination. `reachableUrl` returns it only when the follow *stopped*: a `beforeRedirect` hook threw, or `maxRedirects` ran out. Reporting that as reachable hands the caller a probe that silently failed, and the response `url` is the hop that issued the redirect, not anything that was actually served.

This is live in [unavatar](https://github.com/microlinkhq/unavatar/pull/639): a reserved-address refusal in `beforeRedirect` leaves a 302, `@microlink/ping-url` memoizes `{ url, statusCode }` for a day, and every later cache hit reads `isReachable(302) === true` and serves the attacker URL as a found avatar.

## Fix

A 3xx is the destination only when redirects were not being followed:

```js
const isReachable = ({ statusCode, followRedirect = true }) =>
  isRedirect(statusCode) ? !followRedirect : statusCode >= 200 && statusCode < 300
```

The resolved response now echoes back `followRedirect`, so `isReachable(await reachableUrl(url, opts))` (the documented usage) keeps working with no caller change: `{ followRedirect: false }` still reports its 302 as reachable, an aborted follow no longer does.

The default is `true` so a partial `{ statusCode }` object fails closed. That is the case unavatar hits, because the ping cache drops everything but `url` and `statusCode`.

## Tests

Four new cases in `test/index.js`, all against a local server, no network:

- a redirect refused by a `beforeRedirect` hook is not reachable
- exhausting `maxRedirects` is not reachable
- a redirect is the destination when `followRedirect: false`
- `isReachable` unit table for the bare `{ statusCode }` form

The pre-existing `passing options` test (`followRedirect: false` → 302 → reachable) covers the stamped field end to end and still passes.

`npm run lint` is clean. `test/cache.js` `static asset` and the httpbin-backed tests fail/time out on master too, unrelated to this change.

## Breaking

`isReachable` no longer accepts a 3xx by default. Callers passing the full response are unaffected except for the bug fix. Callers passing a synthetic `{ statusCode }` now get `false` for a redirect status, and should pass `followRedirect: false` (or the whole response) to keep the old result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDDqWqzefzrUSkzq325GbW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `isReachable` semantics for synthetic/partial 3xx objects, but intentional to close a real misclassification bug (e.g. cached probe results); core URL resolution behavior is unchanged aside from the new `followRedirect` field.
> 
> **Overview**
> **Breaking fix for `isReachable`:** redirect statuses (3xx) are no longer treated as reachable when redirects were being followed. Only final **2xx** responses count as reachable in that mode; a leftover 3xx means the follow stopped early (`beforeRedirect` threw, `maxRedirects`, etc.).
> 
> `reachableUrl` now includes **`followRedirect`** on its return value (from options or got defaults), so `isReachable(await reachableUrl(url, opts))` stays correct without caller changes. With **`followRedirect: false`**, a 3xx is still reachable as the intentional answer.
> 
> Bare objects like `{ statusCode: 302 }` default **`followRedirect: true`** and are **unreachable** (fail-closed for caches that only store status codes). README documents `isReachable(response)`; tests add local redirect-server coverage for the new cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587eb5706d7996dae8fffa252899856642484337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->