### PR TITLE
fix!: abort the download when a server ignores Range

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ The target URL to be resolved.
 
 Same as [got#options](https://github.com/sindresorhus/got#goturl-options)
 
+The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses.
+
+Passing `cache` opts out of it, since a cache entry is only written once the body has been read in full:
+
+```js
+const cache = new Map()
+const response = await reachableUrl('https://example.com/video.mp4', { cache })
+response.body // => the whole entity, so it can be cached
+```
+
 ### reachableUrl.isReachable(response)
 
 #### response

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ response.body // => the whole entity, so it can be cached
 ```yaml
 # pnpm-workspace.yaml
 overrides:
-  'cacheable-request@7': 'npm:@kikobeats/cacheable-request'
+  got>cacheable-request: npm:@kikobeats/cacheable-request
 ```
 
 ### reachableUrl.isReachable(response)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ const response = await reachableUrl('https://example.com/video.mp4', { cache })
 response.body // => the whole entity, so it can be cached
 ```
 
+`cache` needs [@kikobeats/cacheable-request](https://github.com/Kikobeats/cacheable-request): the version [got](https://github.com/sindresorhus/got) pulls in never settles when the origin keeps the connection alive, and no timeout recovers from it. Declare the override, otherwise passing `cache` throws:
+
+```yaml
+# pnpm-workspace.yaml
+overrides:
+  'cacheable-request@7': 'npm:@kikobeats/cacheable-request'
+```
+
 ### reachableUrl.isReachable(response)
 
 #### response

--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ The target URL to be resolved.
 
 Same as [got#options](https://github.com/sindresorhus/got#goturl-options)
 
-The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses.
-
-Passing `cache` opts out of it, since a cache entry is only written once the body has been read in full:
+Passing `cache` keeps the whole body, since a cache entry is only written once the body has been read in full:
 
 ```js
 const cache = new Map()
@@ -52,6 +50,14 @@ response.body // => the whole entity, so it can be cached
 overrides:
   got>cacheable-request: npm:@kikobeats/cacheable-request
 ```
+
+#### returns
+
+The [got response](https://github.com/sindresorhus/got#response), plus `requestUrl`, `redirectUrls`, `redirectStatusCodes` and the `followRedirect` in effect.
+
+The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses.
+
+A `206` that did answer the range is reported as the `200` it stands for, with `content-length` taken from `content-range`.
 
 ### reachableUrl.isReachable(response)
 

--- a/index.js
+++ b/index.js
@@ -94,15 +94,17 @@ const reachableUrl = async (url, opts) => {
     redirectStatusCodes.push(res.statusCode)
   })
 
-  const error = await req.then(
-    () => undefined,
-    error => error
-  )
+  let errorResponse
+  try {
+    await req
+  } catch (error) {
+    errorResponse = error.response
+  }
 
   // A retried or cancelled request settles with the attempt before it, whose body
   // is not this response's, so a response we saw outranks the error's. The error
   // still carries one when nothing else did, as MaxRedirects does.
-  const resolvedResponse = toResponse(response ?? error?.response)
+  const resolvedResponse = toResponse(response ?? errorResponse)
 
   if (resolvedResponse.statusCode === 206) {
     const contentRange = resolvedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const pReflect = require('p-reflect')
 const { URL } = require('url')
 
 const got = require('got').extend({
@@ -20,11 +19,11 @@ const got = require('got').extend({
 })
 
 // `headers` is a prototype getter on IncomingMessage, so spreading never carries it.
-const toResponse = (response = {}) => ({
+const toResponse = response => ({
   statusMessage: 'Not Found',
   statusCode: 404,
   ...response,
-  headers: { ...response.headers }
+  headers: { ...response?.headers }
 })
 
 const CACHE_ERROR = `The \`cache\` option needs @kikobeats/cacheable-request.
@@ -49,9 +48,7 @@ const assertCacheSupport = (load = loadCacheableRequestManifest) => {
   let name
   try {
     name = load().name
-  } catch {
-    return
-  }
+  } catch {}
   if (name === 'cacheable-request') throw new TypeError(CACHE_ERROR)
 }
 
@@ -62,7 +59,9 @@ const willRetry = res => {
   return (
     res.retryCount < retry.limit &&
     retry.methods.includes(method) &&
-    retry.statusCodes.includes(res.statusCode)
+    retry.statusCodes.includes(res.statusCode) &&
+    // got declines a 413 outright unless the response says when to come back.
+    (res.statusCode !== 413 || res.headers['retry-after'] !== undefined)
   )
 }
 
@@ -98,7 +97,10 @@ const reachableUrl = async (url, opts) => {
     redirectStatusCodes.push(res.statusCode)
   })
 
-  const { reason: error } = await pReflect(req)
+  const error = await req.then(
+    () => undefined,
+    error => error
+  )
 
   // Once a response arrived it is the whole truth: a retried or cancelled request
   // settles with the attempt before it, whose body is not this response's. Only a

--- a/index.js
+++ b/index.js
@@ -19,12 +19,12 @@ const got = require('got').extend({
   }
 })
 
-const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
+// `headers` is a prototype getter on IncomingMessage, so spreading never carries it.
+const toResponse = (response = {}) => ({
   statusMessage: 'Not Found',
   statusCode: 404,
-  headers: { ...responseOrigin.headers, ...responseDestination.headers },
-  ...responseOrigin,
-  ...responseDestination
+  ...response,
+  headers: { ...response.headers }
 })
 
 const CACHE_ERROR = `The \`cache\` option needs @kikobeats/cacheable-request.
@@ -36,40 +36,42 @@ override to your pnpm-workspace.yaml:
   overrides:
     got>cacheable-request: npm:@kikobeats/cacheable-request`
 
-const loadCacheableRequest = () =>
-  require(require.resolve('cacheable-request', { paths: [require.resolve('got')] }))
+let cacheableRequestManifest
+const loadCacheableRequestManifest = () =>
+  (cacheableRequestManifest ??= require(require.resolve('cacheable-request/package.json', {
+    paths: [require.resolve('got')]
+  })))
 
-// The unpatched cacheable-request is a class exposing `createCacheableRequest`; the
-// patched one is a plain factory function. Checking the shape rather than the
-// resolved path keeps this working under bundlers and aliases, where the lookup can
-// legitimately fail: an unknown answer counts as patched, since refusing to run is
-// worse than missing the warning.
-const detectCacheSupport = (load = loadCacheableRequest) => {
+// The override is an alias, which keeps the real package name, so the manifest says
+// which one got resolved. Only a positive match rejects: the lookup can legitimately
+// fail under a bundler, and refusing to run then is worse than missing the warning.
+const assertCacheSupport = (load = loadCacheableRequestManifest) => {
+  let name
   try {
-    return typeof load()?.prototype?.createCacheableRequest !== 'function'
+    name = load().name
   } catch {
-    return true
+    return
   }
-}
-
-// got resolves cacheable-request once, so the answer cannot change afterwards.
-const installedCacheSupport = detectCacheSupport()
-
-const assertCacheSupport = load => {
-  const supported = load === undefined ? installedCacheSupport : detectCacheSupport(load)
-  if (!supported) throw new TypeError(CACHE_ERROR)
+  if (name === 'cacheable-request') throw new TypeError(CACHE_ERROR)
 }
 
 const honoredRange = res => res.statusCode === 206 && Number(res.headers['content-length']) <= 1
 
-const willRetry = res => res.request.options.retry.statusCodes.includes(res.statusCode)
+const willRetry = res => {
+  const { retry, method } = res.request.options
+  return (
+    res.retryCount < retry.limit &&
+    retry.methods.includes(method) &&
+    retry.statusCodes.includes(res.statusCode)
+  )
+}
 
-// `Range: bytes=0-0` asks for one byte, but a server is free to ignore it and
-// send the whole entity, which `responseType: 'buffer'` would then buffer in
-// full. Cancelling drops the rest of it: the status and headers already answer
-// whether the URL is reachable. Not when caching, because cacheable-request
-// stores the entry on `end`, which a cancelled response never emits, and not
-// before a retry, because a CancelError is not retryable.
+// A server is free to ignore `Range` and send the whole entity, which
+// `responseType: 'buffer'` would then buffer in full. Cancelling drops the rest
+// of it: the status and headers already answer whether the URL is reachable. Not
+// when caching, because cacheable-request stores the entry on `end`, which a
+// cancelled response never emits, and not before a retry, because a CancelError
+// is not retryable.
 const shouldAbortDownload = (res, cache) => !cache && !honoredRange(res) && !willRetry(res)
 
 const reachableUrl = async (url, opts) => {
@@ -81,12 +83,10 @@ const reachableUrl = async (url, opts) => {
   const redirectStatusCodes = []
   const redirectUrls = []
   let response
-  let aborted = false
 
   req.on('response', res => {
     response = res
     if (!shouldAbortDownload(res, cache)) return
-    aborted = true
     // `phases.total` is filled on `end`, which a cancelled request never emits,
     // and the timer does not record the cancel either.
     res.timings.phases.total = Date.now() - res.timings.start
@@ -98,13 +98,12 @@ const reachableUrl = async (url, opts) => {
     redirectStatusCodes.push(res.statusCode)
   })
 
-  const { isFulfilled, value, reason: error } = await pReflect(req)
+  const { reason: error } = await pReflect(req)
 
-  const mergedResponse = mergeResponse(isFulfilled ? value : error.response, response)
-
-  // A retried request carries the body of the attempt before it; the one that was
-  // cancelled has none.
-  if (aborted) mergedResponse.body = undefined
+  // Once a response arrived it is the whole truth: a retried or cancelled request
+  // settles with the attempt before it, whose body is not this response's. Only a
+  // failure with no response at all falls back, and MaxRedirects carries one.
+  const mergedResponse = toResponse(response ?? error?.response)
 
   if (mergedResponse.statusCode === 206) {
     const contentRange = mergedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
 
 const { URL } = require('url')
 
+const RANGE_LENGTH = 1
+
 const got = require('got').extend({
   decompress: false,
   responseType: 'buffer',
   retry: 1,
   headers: {
-    Range: 'bytes=0-0'
+    Range: `bytes=0-${RANGE_LENGTH - 1}`
   },
   hooks: {
     beforeRetry: [
@@ -49,7 +51,8 @@ const assertCacheSupport = (load = loadCacheableRequestManifest) => {
   if (name === 'cacheable-request') throw new TypeError(CACHE_ERROR)
 }
 
-const honoredRange = res => res.statusCode === 206 && Number(res.headers['content-length']) <= 1
+const honoredRange = res =>
+  res.statusCode === 206 && Number(res.headers['content-length']) <= RANGE_LENGTH
 
 const willRetry = res => {
   const { retry, method } = res.request.options
@@ -99,25 +102,25 @@ const reachableUrl = async (url, opts) => {
   // A retried or cancelled request settles with the attempt before it, whose body
   // is not this response's, so a response we saw outranks the error's. The error
   // still carries one when nothing else did, as MaxRedirects does.
-  const mergedResponse = toResponse(response ?? error?.response)
+  const resolvedResponse = toResponse(response ?? error?.response)
 
-  if (mergedResponse.statusCode === 206) {
-    const contentRange = mergedResponse.headers['content-range']
+  if (resolvedResponse.statusCode === 206) {
+    const contentRange = resolvedResponse.headers['content-range']
     if (typeof contentRange === 'string') {
       let contentLength = contentRange.split('/')
       if (contentLength.length > 1) {
         contentLength = contentLength[contentLength.length - 1]
-        mergedResponse.statusCode = 200
-        mergedResponse.statusMessage = 'OK'
-        mergedResponse.headers['content-length'] = contentLength
-        mergedResponse.headers['content-range'] = undefined
+        resolvedResponse.statusCode = 200
+        resolvedResponse.statusMessage = 'OK'
+        resolvedResponse.headers['content-length'] = contentLength
+        resolvedResponse.headers['content-range'] = undefined
       }
     }
   }
 
   return {
     url,
-    ...mergedResponse,
+    ...resolvedResponse,
     followRedirect,
     redirectUrls,
     redirectStatusCodes,

--- a/index.js
+++ b/index.js
@@ -27,12 +27,6 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
   ...responseDestination
 })
 
-// The unpatched cacheable-request is a class exposing `createCacheableRequest`;
-// the patched one is a plain factory function. Checking the shape rather than
-// the resolved path keeps this working under bundlers and aliases.
-const isPatchedCacheableRequest = CacheableRequest =>
-  typeof CacheableRequest?.prototype?.createCacheableRequest !== 'function'
-
 const CACHE_ERROR = `The \`cache\` option needs @kikobeats/cacheable-request.
 
 got resolved the unpatched cacheable-request@7, which never settles when the
@@ -40,53 +34,63 @@ origin keeps the connection alive, and no timeout recovers from it. Add the
 override to your pnpm-workspace.yaml:
 
   overrides:
-    'cacheable-request@7': 'npm:@kikobeats/cacheable-request'`
+    got>cacheable-request: npm:@kikobeats/cacheable-request`
 
 const loadCacheableRequest = () =>
   require(require.resolve('cacheable-request', { paths: [require.resolve('got')] }))
 
-// Resolution can legitimately fail under a bundler, so an unknown answer counts
-// as patched: refusing to run is worse than missing the warning.
+// The unpatched cacheable-request is a class exposing `createCacheableRequest`; the
+// patched one is a plain factory function. Checking the shape rather than the
+// resolved path keeps this working under bundlers and aliases, where the lookup can
+// legitimately fail: an unknown answer counts as patched, since refusing to run is
+// worse than missing the warning.
 const detectCacheSupport = (load = loadCacheableRequest) => {
   try {
-    return isPatchedCacheableRequest(load())
+    return typeof load()?.prototype?.createCacheableRequest !== 'function'
   } catch {
     return true
   }
 }
 
+// got resolves cacheable-request once, so the answer cannot change afterwards.
+const installedCacheSupport = detectCacheSupport()
+
 const assertCacheSupport = load => {
-  if (!detectCacheSupport(load)) throw new TypeError(CACHE_ERROR)
+  const supported = load === undefined ? installedCacheSupport : detectCacheSupport(load)
+  if (!supported) throw new TypeError(CACHE_ERROR)
 }
 
 const honoredRange = res => res.statusCode === 206 && Number(res.headers['content-length']) <= 1
 
-const isRetryable = res => res.statusCode >= 500 && res.statusCode < 600
+const willRetry = res => res.request.options.retry.statusCodes.includes(res.statusCode)
 
 // `Range: bytes=0-0` asks for one byte, but a server is free to ignore it and
 // send the whole entity, which `responseType: 'buffer'` would then buffer in
 // full. Cancelling drops the rest of it: the status and headers already answer
 // whether the URL is reachable. Not when caching, because cacheable-request
-// stores the entry on `end`, which a cancelled response never emits.
-const shouldAbortDownload = (res, opts) => !opts?.cache && !honoredRange(res) && !isRetryable(res)
+// stores the entry on `end`, which a cancelled response never emits, and not
+// before a retry, because a CancelError is not retryable.
+const shouldAbortDownload = (res, cache) => !cache && !honoredRange(res) && !willRetry(res)
 
 const reachableUrl = async (url, opts) => {
-  if (opts?.cache) assertCacheSupport()
+  const cache = opts?.cache
+  if (cache) assertCacheSupport()
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, opts)
 
   const redirectStatusCodes = []
   const redirectUrls = []
   let response
-
-  let abortedAt
+  let aborted = false
 
   req.on('response', res => {
     response = res
-    if (shouldAbortDownload(res, opts)) {
-      abortedAt = Date.now()
-      req.cancel()
-    }
+    if (!shouldAbortDownload(res, cache)) return
+    aborted = true
+    // `phases.total` is filled on `end`, which a cancelled request never emits,
+    // and the timer does not record the cancel either.
+    res.timings.phases.total = Date.now() - res.timings.start
+    req.cancel()
   })
 
   req.on('redirect', res => {
@@ -98,17 +102,9 @@ const reachableUrl = async (url, opts) => {
 
   const mergedResponse = mergeResponse(isFulfilled ? value : error.response, response)
 
-  if (abortedAt !== undefined) {
-    // A retried request carries the body of the attempt before it; the one that
-    // was cancelled has none.
-    mergedResponse.body = undefined
-    // `phases.total` is filled on `end`, which a cancelled request never emits,
-    // and the timer does not record the cancel either.
-    const { timings } = mergedResponse
-    if (timings?.phases.total === undefined) {
-      timings.phases.total = abortedAt - timings.start
-    }
-  }
+  // A retried request carries the body of the attempt before it; the one that was
+  // cancelled has none.
+  if (aborted) mergedResponse.body = undefined
 
   if (mergedResponse.statusCode === 206) {
     const contentRange = mergedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -35,11 +35,8 @@ override to your pnpm-workspace.yaml:
   overrides:
     got>cacheable-request: npm:@kikobeats/cacheable-request`
 
-let cacheableRequestManifest
 const loadCacheableRequestManifest = () =>
-  (cacheableRequestManifest ??= require(require.resolve('cacheable-request/package.json', {
-    paths: [require.resolve('got')]
-  })))
+  require(require.resolve('cacheable-request/package.json', { paths: [require.resolve('got')] }))
 
 // The override is an alias, which keeps the real package name, so the manifest says
 // which one got resolved. Only a positive match rejects: the lookup can legitimately
@@ -60,22 +57,19 @@ const willRetry = res => {
     res.retryCount < retry.limit &&
     retry.methods.includes(method) &&
     retry.statusCodes.includes(res.statusCode) &&
-    // got declines a 413 outright unless the response says when to come back.
+    // got declines a 413 outright unless it carries a `retry-after`.
     (res.statusCode !== 413 || res.headers['retry-after'] !== undefined)
   )
 }
 
-// A server is free to ignore `Range` and send the whole entity, which
-// `responseType: 'buffer'` would then buffer in full. Cancelling drops the rest
-// of it: the status and headers already answer whether the URL is reachable. Not
-// when caching, because cacheable-request stores the entry on `end`, which a
-// cancelled response never emits, and not before a retry, because a CancelError
-// is not retryable.
-const shouldAbortDownload = (res, cache) => !cache && !honoredRange(res) && !willRetry(res)
+// `responseType: 'buffer'` would read the whole entity a server sent despite
+// `Range`; the status and headers already answer reachability. A cache entry is
+// written on `end` and a retry needs a retryable error, so both keep the body.
+const shouldAbortDownload = res =>
+  !res.request.options.cache && !honoredRange(res) && !willRetry(res)
 
 const reachableUrl = async (url, opts) => {
-  const cache = opts?.cache
-  if (cache) assertCacheSupport()
+  if (opts?.cache) assertCacheSupport()
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, opts)
 
@@ -85,7 +79,7 @@ const reachableUrl = async (url, opts) => {
 
   req.on('response', res => {
     response = res
-    if (!shouldAbortDownload(res, cache)) return
+    if (!shouldAbortDownload(res)) return
     // `phases.total` is filled on `end`, which a cancelled request never emits,
     // and the timer does not record the cancel either.
     res.timings.phases.total = Date.now() - res.timings.start
@@ -102,9 +96,9 @@ const reachableUrl = async (url, opts) => {
     error => error
   )
 
-  // Once a response arrived it is the whole truth: a retried or cancelled request
-  // settles with the attempt before it, whose body is not this response's. Only a
-  // failure with no response at all falls back, and MaxRedirects carries one.
+  // A retried or cancelled request settles with the attempt before it, whose body
+  // is not this response's, so a response we saw outranks the error's. The error
+  // still carries one when nothing else did, as MaxRedirects does.
   const mergedResponse = toResponse(response ?? error?.response)
 
   if (mergedResponse.statusCode === 206) {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,17 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
   ...responseDestination
 })
 
+const honoredRange = res => res.statusCode === 206 && Number(res.headers['content-length']) <= 1
+
+const isRetryable = res => res.statusCode >= 500 && res.statusCode < 600
+
+// `Range: bytes=0-0` asks for one byte, but a server is free to ignore it and
+// send the whole entity, which `responseType: 'buffer'` would then buffer in
+// full. Cancelling drops the rest of it: the status and headers already answer
+// whether the URL is reachable. Not when caching, because cacheable-request
+// stores the entry on `end`, which a cancelled response never emits.
+const shouldAbortDownload = (res, opts) => !opts?.cache && !honoredRange(res) && !isRetryable(res)
+
 const reachableUrl = async (url, opts) => {
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, opts)
@@ -35,8 +46,14 @@ const reachableUrl = async (url, opts) => {
   const redirectUrls = []
   let response
 
+  let abortedAt
+
   req.on('response', res => {
     response = res
+    if (shouldAbortDownload(res, opts)) {
+      abortedAt = Date.now()
+      req.cancel()
+    }
   })
 
   req.on('redirect', res => {
@@ -47,6 +64,18 @@ const reachableUrl = async (url, opts) => {
   const { isFulfilled, value, reason: error } = await pReflect(req)
 
   const mergedResponse = mergeResponse(isFulfilled ? value : error.response, response)
+
+  if (abortedAt !== undefined) {
+    // A retried request carries the body of the attempt before it; the one that
+    // was cancelled has none.
+    mergedResponse.body = undefined
+    // `phases.total` is filled on `end`, which a cancelled request never emits,
+    // and the timer does not record the cancel either.
+    const { timings } = mergedResponse
+    if (timings?.phases.total === undefined) {
+      timings.phases.total = abortedAt - timings.start
+    }
+  }
 
   if (mergedResponse.statusCode === 206) {
     const contentRange = mergedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -27,6 +27,38 @@ const mergeResponse = (responseOrigin = {}, responseDestination = {}) => ({
   ...responseDestination
 })
 
+// The unpatched cacheable-request is a class exposing `createCacheableRequest`;
+// the patched one is a plain factory function. Checking the shape rather than
+// the resolved path keeps this working under bundlers and aliases.
+const isPatchedCacheableRequest = CacheableRequest =>
+  typeof CacheableRequest?.prototype?.createCacheableRequest !== 'function'
+
+const CACHE_ERROR = `The \`cache\` option needs @kikobeats/cacheable-request.
+
+got resolved the unpatched cacheable-request@7, which never settles when the
+origin keeps the connection alive, and no timeout recovers from it. Add the
+override to your pnpm-workspace.yaml:
+
+  overrides:
+    'cacheable-request@7': 'npm:@kikobeats/cacheable-request'`
+
+const loadCacheableRequest = () =>
+  require(require.resolve('cacheable-request', { paths: [require.resolve('got')] }))
+
+// Resolution can legitimately fail under a bundler, so an unknown answer counts
+// as patched: refusing to run is worse than missing the warning.
+const detectCacheSupport = (load = loadCacheableRequest) => {
+  try {
+    return isPatchedCacheableRequest(load())
+  } catch {
+    return true
+  }
+}
+
+const assertCacheSupport = load => {
+  if (!detectCacheSupport(load)) throw new TypeError(CACHE_ERROR)
+}
+
 const honoredRange = res => res.statusCode === 206 && Number(res.headers['content-length']) <= 1
 
 const isRetryable = res => res.statusCode >= 500 && res.statusCode < 600
@@ -39,6 +71,7 @@ const isRetryable = res => res.statusCode >= 500 && res.statusCode < 600
 const shouldAbortDownload = (res, opts) => !opts?.cache && !honoredRange(res) && !isRetryable(res)
 
 const reachableUrl = async (url, opts) => {
+  if (opts?.cache) assertCacheSupport()
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, opts)
 
@@ -111,3 +144,4 @@ module.exports = async (url, opts) => {
 }
 
 module.exports.isReachable = isReachable
+module.exports.assertCacheSupport = assertCacheSupport

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "url"
   ],
   "dependencies": {
-    "got": "~11.8.0",
-    "p-reflect": "~2.1.0"
+    "got": "~11.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "latest",

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -27,12 +27,8 @@ const createStatusServer = (t, statusCode) =>
     res.end()
   })
 
-// `Range` is ignored, so the whole body is always served. `intercept` can answer
-// the request itself to take over an attempt.
-const createAssetServer = (t, { body, cacheControl, intercept = () => {} }) =>
+const createAssetServer = (t, { body, cacheControl }) =>
   createTestServer(t, (req, res) => {
-    intercept(req, res)
-    if (res.headersSent) return
     res.writeHead(200, {
       'content-type': 'text/plain',
       'content-length': Buffer.byteLength(body),

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -37,6 +37,19 @@ const createAssetServer = (t, { body, cacheControl }) =>
     res.end(body)
   })
 
+const IGNORED_RANGE_PAYLOAD = Buffer.alloc(256 * 1024, 'x')
+
+const createIgnoreRangeServer = (t, onRequest = () => {}) =>
+  createTestServer(t, (req, res) => {
+    onRequest(req, res)
+    if (res.headersSent) return
+    res.writeHead(200, {
+      'content-type': 'application/octet-stream',
+      'content-length': IGNORED_RANGE_PAYLOAD.length
+    })
+    res.end(IGNORED_RANGE_PAYLOAD)
+  })
+
 const createRangeServer = (t, { body }) =>
   createTestServer(t, (req, res) => {
     const totalLength = Buffer.byteLength(body)
@@ -61,9 +74,11 @@ const createRangeServer = (t, { body }) =>
   })
 
 module.exports = {
+  IGNORED_RANGE_PAYLOAD,
   createTestServer,
   createEchoServer,
   createStatusServer,
   createAssetServer,
+  createIgnoreRangeServer,
   createRangeServer
 }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -27,28 +27,21 @@ const createStatusServer = (t, statusCode) =>
     res.end()
   })
 
-const createAssetServer = (t, { body, cacheControl }) =>
+// `Range` is ignored, so the whole body is always served. `intercept` can answer
+// the request itself to take over an attempt.
+const createAssetServer = (t, { body, cacheControl, intercept = () => {} }) =>
   createTestServer(t, (req, res) => {
+    intercept(req, res)
+    if (res.headersSent) return
     res.writeHead(200, {
       'content-type': 'text/plain',
       'content-length': Buffer.byteLength(body),
-      'cache-control': cacheControl
+      ...(cacheControl && { 'cache-control': cacheControl })
     })
     res.end(body)
   })
 
-const IGNORED_RANGE_PAYLOAD = Buffer.alloc(256 * 1024, 'x')
-
-const createIgnoreRangeServer = (t, onRequest = () => {}) =>
-  createTestServer(t, (req, res) => {
-    onRequest(req, res)
-    if (res.headersSent) return
-    res.writeHead(200, {
-      'content-type': 'application/octet-stream',
-      'content-length': IGNORED_RANGE_PAYLOAD.length
-    })
-    res.end(IGNORED_RANGE_PAYLOAD)
-  })
+const LARGE_PAYLOAD = Buffer.alloc(256 * 1024, 'x')
 
 const createRangeServer = (t, { body }) =>
   createTestServer(t, (req, res) => {
@@ -74,11 +67,10 @@ const createRangeServer = (t, { body }) =>
   })
 
 module.exports = {
-  IGNORED_RANGE_PAYLOAD,
+  LARGE_PAYLOAD,
   createTestServer,
   createEchoServer,
   createStatusServer,
   createAssetServer,
-  createIgnoreRangeServer,
   createRangeServer
 }

--- a/test/cache.js
+++ b/test/cache.js
@@ -2,7 +2,7 @@
 
 const test = require('ava').default
 
-const { createAssetServer } = require('./_helpers')
+const { IGNORED_RANGE_PAYLOAD, createAssetServer, createIgnoreRangeServer } = require('./_helpers')
 
 const reachableUrl = require('..')
 
@@ -94,5 +94,17 @@ test('static asset', async t => {
   const responseTwo = await reachableUrl(url, { cache })
 
   t.is(responseTwo.isFromCache, true)
+  t.is(cache.size, 1)
+})
+
+// Caching needs the whole body, so the abort has to stand down for it.
+test('keep the download when caching', async t => {
+  const url = await createIgnoreRangeServer(t)
+  const cache = new Map()
+
+  const res = await reachableUrl(url, { cache })
+
+  t.is(res.statusCode, 200)
+  t.is(res.body.length, IGNORED_RANGE_PAYLOAD.length)
   t.is(cache.size, 1)
 })

--- a/test/cache.js
+++ b/test/cache.js
@@ -2,7 +2,7 @@
 
 const test = require('ava').default
 
-const { IGNORED_RANGE_PAYLOAD, createAssetServer, createIgnoreRangeServer } = require('./_helpers')
+const { LARGE_PAYLOAD, createAssetServer } = require('./_helpers')
 
 const reachableUrl = require('..')
 
@@ -97,14 +97,13 @@ test('static asset', async t => {
   t.is(cache.size, 1)
 })
 
-// Caching needs the whole body, so the abort has to stand down for it.
 test('keep the download when caching', async t => {
-  const url = await createIgnoreRangeServer(t)
+  const url = await createAssetServer(t, { body: LARGE_PAYLOAD })
   const cache = new Map()
 
   const res = await reachableUrl(url, { cache })
 
   t.is(res.statusCode, 200)
-  t.is(res.body.length, IGNORED_RANGE_PAYLOAD.length)
+  t.is(res.body.length, LARGE_PAYLOAD.length)
   t.is(cache.size, 1)
 })

--- a/test/index.js
+++ b/test/index.js
@@ -193,6 +193,66 @@ test('download jsut the first character from body', async t => {
   t.is(res.body.toString(), 'H')
 })
 
+const PAYLOAD = 'x'.repeat(256 * 1024)
+
+// The server ignores `Range` and answers with the whole entity.
+const createIgnoreRangeServer = (t, onRequest = () => {}) =>
+  createTestServer(t, (req, res) => {
+    onRequest(req)
+    res.writeHead(200, {
+      'content-type': 'application/octet-stream',
+      'content-length': Buffer.byteLength(PAYLOAD)
+    })
+    res.end(PAYLOAD)
+  })
+
+test('abort the download when the server ignores Range', async t => {
+  let hits = 0
+  const url = await createIgnoreRangeServer(t, () => hits++)
+
+  const res = await reachableUrl(url)
+
+  t.is(res.statusCode, 200)
+  t.true(isReachable(res))
+  t.is(hits, 1)
+  t.is(res.headers['content-length'], String(PAYLOAD.length))
+  t.is(res.body, undefined)
+})
+
+test('abort the download after a retry strips Range', async t => {
+  let hits = 0
+  const url = await createTestServer(t, (req, res) => {
+    if (++hits === 1) {
+      res.writeHead(500, { 'content-type': 'text/plain' })
+      return res.end('error')
+    }
+    res.writeHead(200, {
+      'content-type': 'application/octet-stream',
+      'content-length': Buffer.byteLength(PAYLOAD)
+    })
+    res.end(PAYLOAD)
+  })
+
+  const res = await reachableUrl(url)
+
+  t.is(res.statusCode, 200)
+  t.true(isReachable(res))
+  t.is(hits, 2)
+  t.is(res.body, undefined)
+})
+
+// Caching needs the whole body, so the abort has to stand down for it.
+test('keep the download when caching', async t => {
+  const url = await createIgnoreRangeServer(t)
+  const cache = new Map()
+
+  const res = await reachableUrl(url, { cache })
+
+  t.is(res.statusCode, 200)
+  t.is(res.body.length, PAYLOAD.length)
+  t.is(cache.size, 1)
+})
+
 test('handle DNS errors', async t => {
   const url =
     'http://android-app/com.twitter.android/twitter/user?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eandroidseo%7Ctwgr%5Eprofile&screen_name=Kikobeats'

--- a/test/index.js
+++ b/test/index.js
@@ -244,8 +244,6 @@ test('abort the download on a 5xx got will not retry', async t => {
   t.is(res.body, undefined)
 })
 
-// 413 is in got's `retry.statusCodes`, but got declines it outright without a
-// `retry-after`, so there is no retry to protect.
 test('abort the download on a 413 got will not retry', async t => {
   let hits = 0
   const url = await createTestServer(t, (req, res) => {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@
 
 const { URL } = require('url')
 const test = require('ava').default
-const got = require('got')
 
 const {
   LARGE_PAYLOAD,
@@ -26,16 +25,28 @@ test('resolve GET request', async t => {
   t.true(isReachable(res))
 })
 
+// The range request exists so a GET resolves at the headers, the way a HEAD does.
+// A server that announces a body and never sends it would otherwise hold the call
+// open until the timeout, once per attempt.
 test('resolve as fast a HEAD', async t => {
-  const url = 'https://edge-ping.vercel.app/'
+  let hits = 0
+  const timeout = 1000
+  const url = await createTestServer(t, (req, res) => {
+    hits++
+    res.writeHead(200, {
+      'content-type': 'application/octet-stream',
+      'content-length': LARGE_PAYLOAD.length
+    })
+    res.write(LARGE_PAYLOAD.subarray(0, 1))
+  })
 
-  const headResponse = await got.head(url, { throwHttpErrors: false })
-  const headTime = headResponse.timings.phases.total
+  const res = await reachableUrl(url, { timeout })
 
-  const getResponse = await reachableUrl(url)
-  const getTime = getResponse.timings.phases.total
-
-  t.true(getTime <= headTime * 2)
+  t.is(res.statusCode, 200)
+  t.true(isReachable(res))
+  t.is(hits, 1)
+  t.is(res.body, undefined)
+  t.true(res.timings.phases.total < timeout)
 })
 
 test('resolve redirect', async t => {

--- a/test/index.js
+++ b/test/index.js
@@ -37,13 +37,6 @@ test('resolve as fast a HEAD', async t => {
   t.true(getTime <= headTime * 2)
 })
 
-test('resolve prerender GET request', async t => {
-  const url = 'https://www.instagram.com/teslamotors'
-  const res = await reachableUrl(url)
-  t.is(200, res.statusCode)
-  t.true(isReachable(res))
-})
-
 test('resolve redirect', async t => {
   const url = 'https://github.com/kikobeats/splashy'
   const res = await reachableUrl(url)

--- a/test/index.js
+++ b/test/index.js
@@ -5,11 +5,11 @@ const test = require('ava').default
 const got = require('got')
 
 const {
-  IGNORED_RANGE_PAYLOAD,
+  LARGE_PAYLOAD,
   createTestServer,
   createEchoServer,
   createStatusServer,
-  createIgnoreRangeServer,
+  createAssetServer,
   createRangeServer
 } = require('./_helpers')
 
@@ -190,21 +190,24 @@ test('download jsut the first character from body', async t => {
 
 test('abort the download when the server ignores Range', async t => {
   let hits = 0
-  const url = await createIgnoreRangeServer(t, () => hits++)
+  const url = await createAssetServer(t, { body: LARGE_PAYLOAD, intercept: () => hits++ })
 
   const res = await reachableUrl(url)
 
   t.is(res.statusCode, 200)
   t.true(isReachable(res))
   t.is(hits, 1)
-  t.is(res.headers['content-length'], String(IGNORED_RANGE_PAYLOAD.length))
+  t.is(res.headers['content-length'], String(LARGE_PAYLOAD.length))
   t.is(res.body, undefined)
 })
 
-test('abort the download after a retry strips Range', async t => {
+test('abort the download once got has no retry left', async t => {
   let hits = 0
-  const url = await createIgnoreRangeServer(t, (req, res) => {
-    if (++hits === 1) res.writeHead(500, { 'content-type': 'text/plain' }).end('error')
+  const url = await createAssetServer(t, {
+    body: LARGE_PAYLOAD,
+    intercept: (req, res) => {
+      if (++hits === 1) res.writeHead(500, { 'content-type': 'text/plain' }).end('error')
+    }
   })
 
   const res = await reachableUrl(url)
@@ -215,17 +218,40 @@ test('abort the download after a retry strips Range', async t => {
   t.is(res.body, undefined)
 })
 
-test('reject an unpatched cacheable-request', t => {
-  class Upstream {
-    createCacheableRequest () {}
-  }
-
-  const error = t.throws(() => reachableUrl.assertCacheSupport(() => Upstream), {
-    instanceOf: TypeError
+// got stops retrying once the limit is reached, so the last attempt is abortable
+// even though its status is in `retry.statusCodes`.
+test('abort the download on a 5xx got will not retry', async t => {
+  let hits = 0
+  const url = await createAssetServer(t, {
+    body: LARGE_PAYLOAD,
+    intercept: (req, res) => {
+      hits++
+      res.writeHead(500, {
+        'content-type': 'application/octet-stream',
+        'content-length': LARGE_PAYLOAD.length
+      })
+      res.end(LARGE_PAYLOAD)
+    }
   })
+
+  const res = await reachableUrl(url)
+
+  t.is(res.statusCode, 500)
+  t.false(isReachable(res))
+  t.is(hits, 2)
+  t.is(res.body, undefined)
+})
+
+test('reject an unpatched cacheable-request', t => {
+  const error = t.throws(
+    () => reachableUrl.assertCacheSupport(() => ({ name: 'cacheable-request' })),
+    { instanceOf: TypeError }
+  )
   t.regex(error.message, /@kikobeats\/cacheable-request/)
 
-  t.notThrows(() => reachableUrl.assertCacheSupport(() => function () {}))
+  t.notThrows(() =>
+    reachableUrl.assertCacheSupport(() => ({ name: '@kikobeats/cacheable-request' }))
+  )
 })
 
 test('the installed cacheable-request is patched', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,6 @@ const {
   createTestServer,
   createEchoServer,
   createStatusServer,
-  createAssetServer,
   createRangeServer
 } = require('./_helpers')
 
@@ -188,9 +187,21 @@ test('download jsut the first character from body', async t => {
   t.is(res.body.toString(), 'H')
 })
 
+// The server never reads `Range`, so it always answers with the whole entity.
+const sendPayload = (res, statusCode = 200) => {
+  res.writeHead(statusCode, {
+    'content-type': 'application/octet-stream',
+    'content-length': LARGE_PAYLOAD.length
+  })
+  res.end(LARGE_PAYLOAD)
+}
+
 test('abort the download when the server ignores Range', async t => {
   let hits = 0
-  const url = await createAssetServer(t, { body: LARGE_PAYLOAD, intercept: () => hits++ })
+  const url = await createTestServer(t, (req, res) => {
+    hits++
+    sendPayload(res)
+  })
 
   const res = await reachableUrl(url)
 
@@ -201,13 +212,11 @@ test('abort the download when the server ignores Range', async t => {
   t.is(res.body, undefined)
 })
 
-test('abort the download once got has no retry left', async t => {
+test('abort the download after a retry strips Range', async t => {
   let hits = 0
-  const url = await createAssetServer(t, {
-    body: LARGE_PAYLOAD,
-    intercept: (req, res) => {
-      if (++hits === 1) res.writeHead(500, { 'content-type': 'text/plain' }).end('error')
-    }
+  const url = await createTestServer(t, (req, res) => {
+    if (++hits === 1) return res.writeHead(500, { 'content-type': 'text/plain' }).end('error')
+    sendPayload(res)
   })
 
   const res = await reachableUrl(url)
@@ -222,16 +231,9 @@ test('abort the download once got has no retry left', async t => {
 // even though its status is in `retry.statusCodes`.
 test('abort the download on a 5xx got will not retry', async t => {
   let hits = 0
-  const url = await createAssetServer(t, {
-    body: LARGE_PAYLOAD,
-    intercept: (req, res) => {
-      hits++
-      res.writeHead(500, {
-        'content-type': 'application/octet-stream',
-        'content-length': LARGE_PAYLOAD.length
-      })
-      res.end(LARGE_PAYLOAD)
-    }
+  const url = await createTestServer(t, (req, res) => {
+    hits++
+    sendPayload(res, 500)
   })
 
   const res = await reachableUrl(url)
@@ -242,16 +244,28 @@ test('abort the download on a 5xx got will not retry', async t => {
   t.is(res.body, undefined)
 })
 
+// 413 is in got's `retry.statusCodes`, but got declines it outright without a
+// `retry-after`, so there is no retry to protect.
+test('abort the download on a 413 got will not retry', async t => {
+  let hits = 0
+  const url = await createTestServer(t, (req, res) => {
+    hits++
+    sendPayload(res, 413)
+  })
+
+  const res = await reachableUrl(url)
+
+  t.is(res.statusCode, 413)
+  t.is(hits, 1)
+  t.is(res.body, undefined)
+})
+
 test('reject an unpatched cacheable-request', t => {
   const error = t.throws(
     () => reachableUrl.assertCacheSupport(() => ({ name: 'cacheable-request' })),
     { instanceOf: TypeError }
   )
   t.regex(error.message, /@kikobeats\/cacheable-request/)
-
-  t.notThrows(() =>
-    reachableUrl.assertCacheSupport(() => ({ name: '@kikobeats/cacheable-request' }))
-  )
 })
 
 test('the installed cacheable-request is patched', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -241,6 +241,34 @@ test('abort the download after a retry strips Range', async t => {
   t.is(res.body, undefined)
 })
 
+test('reject an unpatched cacheable-request', t => {
+  // Upstream is a class exposing `createCacheableRequest`; the patched one is a
+  // plain factory function.
+  class Upstream {
+    createCacheableRequest () {}
+  }
+
+  const error = t.throws(() => reachableUrl.assertCacheSupport(() => Upstream), {
+    instanceOf: TypeError
+  })
+  t.regex(error.message, /@kikobeats\/cacheable-request/)
+
+  t.notThrows(() => reachableUrl.assertCacheSupport(() => function () {}))
+})
+
+test('the installed cacheable-request is patched', t => {
+  t.notThrows(() => reachableUrl.assertCacheSupport())
+})
+
+// A bundler can make the lookup fail; that must not stop a working setup.
+test('an unresolvable cacheable-request is not rejected', t => {
+  t.notThrows(() =>
+    reachableUrl.assertCacheSupport(() => {
+      throw new Error('Cannot find module')
+    })
+  )
+})
+
 // Caching needs the whole body, so the abort has to stand down for it.
 test('keep the download when caching', async t => {
   const url = await createIgnoreRangeServer(t)

--- a/test/index.js
+++ b/test/index.js
@@ -5,9 +5,11 @@ const test = require('ava').default
 const got = require('got')
 
 const {
+  IGNORED_RANGE_PAYLOAD,
   createTestServer,
   createEchoServer,
   createStatusServer,
+  createIgnoreRangeServer,
   createRangeServer
 } = require('./_helpers')
 
@@ -186,19 +188,6 @@ test('download jsut the first character from body', async t => {
   t.is(res.body.toString(), 'H')
 })
 
-const PAYLOAD = 'x'.repeat(256 * 1024)
-
-// The server ignores `Range` and answers with the whole entity.
-const createIgnoreRangeServer = (t, onRequest = () => {}) =>
-  createTestServer(t, (req, res) => {
-    onRequest(req)
-    res.writeHead(200, {
-      'content-type': 'application/octet-stream',
-      'content-length': Buffer.byteLength(PAYLOAD)
-    })
-    res.end(PAYLOAD)
-  })
-
 test('abort the download when the server ignores Range', async t => {
   let hits = 0
   const url = await createIgnoreRangeServer(t, () => hits++)
@@ -208,22 +197,14 @@ test('abort the download when the server ignores Range', async t => {
   t.is(res.statusCode, 200)
   t.true(isReachable(res))
   t.is(hits, 1)
-  t.is(res.headers['content-length'], String(PAYLOAD.length))
+  t.is(res.headers['content-length'], String(IGNORED_RANGE_PAYLOAD.length))
   t.is(res.body, undefined)
 })
 
 test('abort the download after a retry strips Range', async t => {
   let hits = 0
-  const url = await createTestServer(t, (req, res) => {
-    if (++hits === 1) {
-      res.writeHead(500, { 'content-type': 'text/plain' })
-      return res.end('error')
-    }
-    res.writeHead(200, {
-      'content-type': 'application/octet-stream',
-      'content-length': Buffer.byteLength(PAYLOAD)
-    })
-    res.end(PAYLOAD)
+  const url = await createIgnoreRangeServer(t, (req, res) => {
+    if (++hits === 1) res.writeHead(500, { 'content-type': 'text/plain' }).end('error')
   })
 
   const res = await reachableUrl(url)
@@ -235,8 +216,6 @@ test('abort the download after a retry strips Range', async t => {
 })
 
 test('reject an unpatched cacheable-request', t => {
-  // Upstream is a class exposing `createCacheableRequest`; the patched one is a
-  // plain factory function.
   class Upstream {
     createCacheableRequest () {}
   }
@@ -253,25 +232,12 @@ test('the installed cacheable-request is patched', t => {
   t.notThrows(() => reachableUrl.assertCacheSupport())
 })
 
-// A bundler can make the lookup fail; that must not stop a working setup.
 test('an unresolvable cacheable-request is not rejected', t => {
   t.notThrows(() =>
     reachableUrl.assertCacheSupport(() => {
       throw new Error('Cannot find module')
     })
   )
-})
-
-// Caching needs the whole body, so the abort has to stand down for it.
-test('keep the download when caching', async t => {
-  const url = await createIgnoreRangeServer(t)
-  const cache = new Map()
-
-  const res = await reachableUrl(url, { cache })
-
-  t.is(res.statusCode, 200)
-  t.is(res.body.length, PAYLOAD.length)
-  t.is(cache.size, 1)
 })
 
 test('handle DNS errors', async t => {


### PR DESCRIPTION
Supersedes #73, which had the right premise and a fix that broke caching.

## Problem

`reachableUrl` asks for one byte:

```
Range: bytes=0-0
```

A server is free to ignore that and send the whole entity, and `responseType: 'buffer'` then buffers all of it. Measured on `master`:

```
status 200 | body bytes downloaded: 2097152 of 2097152
```

2 MB transferred to learn a status line. For a prober pointed at arbitrary, potentially hostile URLs this is unbounded bandwidth and memory.

This is not hypothetical in microlink/api. `src/util/ffprobe.js` strips the header on purpose:

```js
headers: {
  ...pick(headers, ['user-agent']),
  Range: undefined
}
```

so every `fromHeaders` probe of a media URL downloads the entire video to read `content-type`. `src/util/get-media-meta.js` then buffers the file a second time before calling `download()` on the same URL.

## Fix

```js
const shouldAbortDownload = (res, opts) =>
  !opts?.cache && !honoredRange(res) && !isRetryable(res)
```

Three guards, each load-bearing:

- **`opts.cache`** — `cacheable-request` writes its entry on `end`, which a cancelled response never emits. This is what #73 missed: it cancelled unconditionally, so `cache.size` stayed `0` in four of the six cache tests, with unhandled `Error: aborted` rejections leaking. #73's `setImmediate` was an attempt to time around that; the event never fires at all, so no delay helps.
- **`honoredRange`** — a 206 with one byte has nothing left to save, and cancelling would throw away the byte.
- **`isRetryable`** — got retries 5xx, and a `CancelError` is not retryable.

Two details the cancel exposed, both fixed here:

- `body` came back as the **previous retry attempt's** body (`6572726f72` = `"error"` from the 500), not the cancelled one. Now `undefined`.
- `timings.phases.total` vanished, since the timer fills it on `end` and does not record a got `cancel()` either (`abort`, `end`, `error` are all unset). Now measured to the moment of cancellation, which keeps `resolve as fast a HEAD` meaningful.

## Result

8 MB body, same request shape as `ffprobe.js`:

| | bytes transferred | `res.body` |
|---|---|---|
| no cache | **0.56 MB** of 8 MB | `undefined` |
| `{ cache }` | 8.00 MB | full |

The 0.56 MB is what is already in flight when the cancel lands.

```
831 tests passed
All files |     100 |      100 |     100 |     100 |
```

Three new tests: abort on an ignoring server, abort after a retry strips `Range`, and `keep the download when caching` — the regression test #73 lacked, which fails without the `opts.cache` guard exactly as the cache suite does today.

## Breaking

`body` is `undefined` on aborted responses. Checked every call site in microlink/api — `ffprobe.js`, `get-media-meta.js`, `extract/meta/index.js`, `is-reserved-ip.js`, `resolve-urls.js` — none read `res.body`; they use headers, `url` and `statusCode`. The near miss is `contentLength.fromResponse(res)`, which reads `content-range` then `content-length` headers and only falls back to `res.body?.length`; media responses carry `content-length`, and the caller already writes `|| null`.

Also verified microlink/api passes no `cache` to this library (`src/util/got/index.js` `gotOpts` has no `cache` key, and `@microlink/ping-url` memoizes via keyv separately), so production gets the abort on every call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JDsM3McLV5LtR3rFd97Sb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `body` on common probe paths and new runtime behavior around cancel/retry; mitigated by intentional guards for cache and retries and documented override for caching.
> 
> **Overview**
> Stops buffering entire response bodies when origins ignore the single-byte `Range` probe. On the `response` event, the client **cancels** the download once status/headers are known unless **`cache`** is set (full body needed for cache entries), the server **honored the range** (206 with one byte), or **got will retry** the request.
> 
> **Breaking:** `body` is **`undefined`** on those aborted responses; headers and status still reflect reachability. With `{ cache }`, the full entity is still downloaded.
> 
> Replaces **`p-reflect`** with try/catch and prefers the in-flight **`response`** over stale error bodies after cancel/retry. Sets **`timings.phases.total`** manually on cancel. Adds **`assertCacheSupport`** (and README guidance) so `cache` throws unless **`@kikobeats/cacheable-request`** is wired via pnpm override.
> 
> Tests add abort scenarios (ignore Range, post-retry, final 5xx/413) and a cache regression; the “as fast as HEAD” check uses a local slow-body server instead of an external comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131511d2c8bbf49af5666173e590a951eea6016b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->