### PR TITLE
feat: add maxBody to keep part of an aborted download

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Same as [got#options](https://github.com/sindresorhus/got#goturl-options), plus:
 Type: `number`<br>
 Default: `0`
 
-How many bytes of the body to keep before the download is cancelled.
+How many bytes of the body to keep when the download would otherwise be cancelled. A positive integer or `Infinity`; anything else throws.
 
 The default answers reachability from the status and headers alone, never reading a body. Ask for more when the bytes themselves decide something:
 
@@ -77,7 +77,7 @@ overrides:
 
 The [got response](https://github.com/sindresorhus/got#response), plus `requestUrl`, `redirectUrls`, `redirectStatusCodes` and the `followRedirect` in effect.
 
-The request asks for a single byte ([`Range: bytes=0-0`](#maxbody)). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses unless [`maxBody`](#maxbody) asked for some of it.
+By default the request asks for a single byte (`Range: bytes=0-0`, which [`maxBody`](#maxbody) drops when it wants more). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses unless [`maxBody`](#maxbody) asked for some of it.
 
 A `206` that did answer the range is reported as the `200` it stands for, with `content-length` taken from `content-range`.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,31 @@ The target URL to be resolved.
 
 #### options
 
-Same as [got#options](https://github.com/sindresorhus/got#goturl-options)
+Same as [got#options](https://github.com/sindresorhus/got#goturl-options), plus:
 
-Passing `cache` keeps the whole body, since a cache entry is only written once the body has been read in full:
+##### maxBody
+
+Type: `number`<br>
+Default: `0`
+
+How many bytes of the body to keep before the download is cancelled.
+
+The default answers reachability from the status and headers alone, never reading a body. Ask for more when the bytes themselves decide something:
+
+```js
+// one byte is enough to tell an image from an HTML error page served as one
+const response = await reachableUrl('https://example.com/favicon.png', { maxBody: 1 })
+response.body[0] === 60 // => `<`, so the server answered with markup
+```
+
+`Infinity` keeps the whole entity, and drops the `Range` header with it, since asking for one byte while wanting all of them would have a server that honors ranges answer with just that byte:
+
+```js
+const response = await reachableUrl('https://example.com/favicon.svg', { maxBody: Infinity })
+response.body // => the whole entity
+```
+
+Passing `cache` keeps the whole body too, since a cache entry is only written once the body has been read in full:
 
 ```js
 const cache = new Map()
@@ -55,7 +77,7 @@ overrides:
 
 The [got response](https://github.com/sindresorhus/got#response), plus `requestUrl`, `redirectUrls`, `redirectStatusCodes` and the `followRedirect` in effect.
 
-The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses.
+The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses unless [`maxBody`](#maxbody) asked for some of it.
 
 A `206` that did answer the range is reported as the `200` it stands for, with `content-length` taken from `content-range`.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const response = await reachableUrl('https://example.com/favicon.png', { maxBody
 response.body[0] === 60 // => `<`, so the server answered with markup
 ```
 
-`Infinity` keeps the whole entity, and drops the `Range` header with it, since asking for one byte while wanting all of them would have a server that honors ranges answer with just that byte:
+Asking for more than one byte drops the `Range` header, since a server that honors it would answer with just that byte. `Infinity` is the extreme of that, and keeps the whole entity:
 
 ```js
 const response = await reachableUrl('https://example.com/favicon.svg', { maxBody: Infinity })
@@ -77,7 +77,7 @@ overrides:
 
 The [got response](https://github.com/sindresorhus/got#response), plus `requestUrl`, `redirectUrls`, `redirectStatusCodes` and the `followRedirect` in effect.
 
-The request asks for a single byte (`Range: bytes=0-0`). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses unless [`maxBody`](#maxbody) asked for some of it.
+The request asks for a single byte ([`Range: bytes=0-0`](#maxbody)). When a server ignores that and starts sending the whole entity, the download is cancelled: the status and headers already say whether the URL is reachable, so `body` is `undefined` on those responses unless [`maxBody`](#maxbody) asked for some of it.
 
 A `206` that did answer the range is reported as the `200` it stands for, with `content-length` taken from `content-range`.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Same as [got#options](https://github.com/sindresorhus/got#goturl-options), plus:
 Type: `number`<br>
 Default: `0`
 
-How many bytes of the body to keep when the download would otherwise be cancelled. A positive integer or `Infinity`; anything else throws.
+How many bytes of the body to keep when the download would otherwise be cancelled. A non-negative integer or `Infinity`; anything else throws.
 
 The default answers reachability from the status and headers alone, never reading a body. Ask for more when the bytes themselves decide something:
 

--- a/index.js
+++ b/index.js
@@ -71,22 +71,43 @@ const willRetry = res => {
 const shouldAbortDownload = res =>
   !res.request.options.cache && !honoredRange(res) && !willRetry(res)
 
+// Asking for a range while wanting more of the body than it holds is
+// contradictory: a server honoring it would answer with that one byte.
+const toGotOptions = ({ maxBody, ...opts }) =>
+  maxBody > RANGE_LENGTH ? { ...opts, headers: { ...opts.headers, Range: undefined } } : opts
+
 const reachableUrl = async (url, opts) => {
   if (opts?.cache) assertCacheSupport()
+  const maxBody = opts?.maxBody ?? 0
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
-  const req = got(url, opts)
+  const req = got(url, toGotOptions({ ...opts }))
 
   const redirectStatusCodes = []
   const redirectUrls = []
   let response
+  let body
 
   req.on('response', res => {
     response = res
-    if (!shouldAbortDownload(res)) return
-    // `phases.total` is filled on `end`, which a cancelled request never emits,
-    // and the timer does not record the cancel either.
-    res.timings.phases.total = Date.now() - res.timings.start
-    req.cancel()
+    if (maxBody === Infinity || !shouldAbortDownload(res)) return
+
+    const abort = () => {
+      // `phases.total` is filled on `end`, which a cancelled request never emits,
+      // and the timer does not record the cancel either.
+      res.timings.phases.total = Date.now() - res.timings.start
+      req.cancel()
+    }
+
+    if (maxBody === 0) return abort()
+
+    const chunks = []
+    let read = 0
+    res.on('data', chunk => {
+      chunks.push(chunk)
+      if ((read += chunk.length) < maxBody) return
+      body = Buffer.concat(chunks).subarray(0, maxBody)
+      abort()
+    })
   })
 
   req.on('redirect', res => {
@@ -105,6 +126,8 @@ const reachableUrl = async (url, opts) => {
   // is not this response's, so a response we saw outranks the error's. The error
   // still carries one when nothing else did, as MaxRedirects does.
   const resolvedResponse = toResponse(response ?? errorResponse)
+
+  if (body !== undefined) resolvedResponse.body = body
 
   if (resolvedResponse.statusCode === 206) {
     const contentRange = resolvedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -67,14 +67,14 @@ const willRetry = res => {
 
 // `responseType: 'buffer'` would read the whole entity a server sent despite
 // `Range`; the status and headers already answer reachability. A cache entry is
-// written on `end` and a retry needs a retryable error, so both keep the body.
-const shouldAbortDownload = res =>
-  !res.request.options.cache && !honoredRange(res) && !willRetry(res)
+// written on `end`, a retry needs a retryable error and `maxBody: Infinity` was
+// asked for the entity, so all three keep the body.
+const shouldAbortDownload = (res, maxBody) =>
+  maxBody !== Infinity && !res.request.options.cache && !honoredRange(res) && !willRetry(res)
 
 // Asking for a range while wanting more of the body than it holds is
 // contradictory: a server honoring it would answer with that one byte.
-const toGotOptions = ({ maxBody, ...opts } = {}) =>
-  maxBody > RANGE_LENGTH ? { ...opts, headers: { ...opts.headers, Range: undefined } } : opts
+const withoutRange = opts => ({ ...opts, headers: { ...opts.headers, Range: undefined } })
 
 const cancelDownload = (req, res) => {
   // `phases.total` is filled on `end`, which a cancelled request never emits,
@@ -83,11 +83,10 @@ const cancelDownload = (req, res) => {
   req.cancel()
 }
 
-const reachableUrl = async (url, opts) => {
-  if (opts?.cache) assertCacheSupport()
-  const maxBody = opts?.maxBody ?? 0
-  const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
-  const req = got(url, toGotOptions(opts))
+const reachableUrl = async (url, { maxBody = 0, ...opts } = {}) => {
+  if (opts.cache) assertCacheSupport()
+  const followRedirect = opts.followRedirect ?? got.defaults.options.followRedirect
+  const req = got(url, maxBody > RANGE_LENGTH ? withoutRange(opts) : opts)
 
   const redirectStatusCodes = []
   const redirectUrls = []
@@ -95,8 +94,10 @@ const reachableUrl = async (url, opts) => {
 
   req.on('response', res => {
     response = res
-    if (maxBody === Infinity || !shouldAbortDownload(res)) return
+    if (!shouldAbortDownload(res, maxBody)) return
     if (maxBody === 0) return cancelDownload(req, res)
+    // An entity that already fits is read to the end, so got fills `body` itself.
+    if (Number(res.headers['content-length']) <= maxBody) return
 
     const chunks = []
     let read = 0

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const willRetry = res => {
 
 // `responseType: 'buffer'` would read the whole entity a server sent despite
 // `Range`; the status and headers already answer reachability. A cache entry is
-// written on `end`, a retry needs a retryable error and `maxBody: Infinity` was
+// written on `end`, a retry needs a retryable error, and `maxBody: Infinity`
 // asked for the entity, so all three keep the body.
 const shouldAbortDownload = (res, maxBody) =>
   maxBody !== Infinity && !res.request.options.cache && !honoredRange(res) && !willRetry(res)
@@ -101,7 +101,7 @@ const keepFirstBytes = (req, res, maxBody) => {
 // uncatchable, so a value it cannot take is refused before the socket opens.
 const assertMaxBody = maxBody => {
   if (maxBody === Infinity || (Number.isInteger(maxBody) && maxBody >= 0)) return
-  throw new TypeError('`maxBody` needs to be a positive integer or `Infinity`.')
+  throw new TypeError('`maxBody` needs to be a non-negative integer or `Infinity`.')
 }
 
 const reachableUrl = async (url, { maxBody = 0, ...opts } = {}) => {
@@ -118,8 +118,6 @@ const reachableUrl = async (url, { maxBody = 0, ...opts } = {}) => {
     response = res
     if (!shouldAbortDownload(res, maxBody)) return
     if (maxBody === 0) return cancelDownload(req, res)
-    // An entity that already fits is read to the end, so got fills `body` itself.
-    if (Number(res.headers['content-length']) <= maxBody) return
     keepFirstBytes(req, res, maxBody)
   })
 

--- a/index.js
+++ b/index.js
@@ -73,41 +73,42 @@ const shouldAbortDownload = res =>
 
 // Asking for a range while wanting more of the body than it holds is
 // contradictory: a server honoring it would answer with that one byte.
-const toGotOptions = ({ maxBody, ...opts }) =>
+const toGotOptions = ({ maxBody, ...opts } = {}) =>
   maxBody > RANGE_LENGTH ? { ...opts, headers: { ...opts.headers, Range: undefined } } : opts
+
+const cancelDownload = (req, res) => {
+  // `phases.total` is filled on `end`, which a cancelled request never emits,
+  // and the timer does not record the cancel either.
+  res.timings.phases.total = Date.now() - res.timings.start
+  req.cancel()
+}
 
 const reachableUrl = async (url, opts) => {
   if (opts?.cache) assertCacheSupport()
   const maxBody = opts?.maxBody ?? 0
   const followRedirect = opts?.followRedirect ?? got.defaults.options.followRedirect
-  const req = got(url, toGotOptions({ ...opts }))
+  const req = got(url, toGotOptions(opts))
 
   const redirectStatusCodes = []
   const redirectUrls = []
   let response
-  let body
 
   req.on('response', res => {
     response = res
     if (maxBody === Infinity || !shouldAbortDownload(res)) return
-
-    const abort = () => {
-      // `phases.total` is filled on `end`, which a cancelled request never emits,
-      // and the timer does not record the cancel either.
-      res.timings.phases.total = Date.now() - res.timings.start
-      req.cancel()
-    }
-
-    if (maxBody === 0) return abort()
+    if (maxBody === 0) return cancelDownload(req, res)
 
     const chunks = []
     let read = 0
-    res.on('data', chunk => {
+    // The cancel is not immediate, so chunks already in flight keep arriving.
+    const onData = chunk => {
       chunks.push(chunk)
       if ((read += chunk.length) < maxBody) return
-      body = Buffer.concat(chunks).subarray(0, maxBody)
-      abort()
-    })
+      res.off('data', onData)
+      res.body = Buffer.concat(chunks, maxBody)
+      cancelDownload(req, res)
+    }
+    res.on('data', onData)
   })
 
   req.on('redirect', res => {
@@ -126,8 +127,6 @@ const reachableUrl = async (url, opts) => {
   // is not this response's, so a response we saw outranks the error's. The error
   // still carries one when nothing else did, as MaxRedirects does.
   const resolvedResponse = toResponse(response ?? errorResponse)
-
-  if (body !== undefined) resolvedResponse.body = body
 
   if (resolvedResponse.statusCode === 206) {
     const contentRange = resolvedResponse.headers['content-range']

--- a/index.js
+++ b/index.js
@@ -83,7 +83,29 @@ const cancelDownload = (req, res) => {
   req.cancel()
 }
 
+const keepFirstBytes = (req, res, maxBody) => {
+  const chunks = []
+  let read = 0
+  // The cancel is not immediate, so chunks already in flight keep arriving.
+  const onData = chunk => {
+    chunks.push(chunk)
+    if ((read += chunk.length) < maxBody) return
+    res.off('data', onData)
+    res.body = Buffer.concat(chunks, maxBody)
+    cancelDownload(req, res)
+  }
+  res.on('data', onData)
+}
+
+// The count reaches `Buffer.concat` inside a stream callback, where a throw is
+// uncatchable, so a value it cannot take is refused before the socket opens.
+const assertMaxBody = maxBody => {
+  if (maxBody === Infinity || (Number.isInteger(maxBody) && maxBody >= 0)) return
+  throw new TypeError('`maxBody` needs to be a positive integer or `Infinity`.')
+}
+
 const reachableUrl = async (url, { maxBody = 0, ...opts } = {}) => {
+  assertMaxBody(maxBody)
   if (opts.cache) assertCacheSupport()
   const followRedirect = opts.followRedirect ?? got.defaults.options.followRedirect
   const req = got(url, maxBody > RANGE_LENGTH ? withoutRange(opts) : opts)
@@ -98,18 +120,7 @@ const reachableUrl = async (url, { maxBody = 0, ...opts } = {}) => {
     if (maxBody === 0) return cancelDownload(req, res)
     // An entity that already fits is read to the end, so got fills `body` itself.
     if (Number(res.headers['content-length']) <= maxBody) return
-
-    const chunks = []
-    let read = 0
-    // The cancel is not immediate, so chunks already in flight keep arriving.
-    const onData = chunk => {
-      chunks.push(chunk)
-      if ((read += chunk.length) < maxBody) return
-      res.off('data', onData)
-      res.body = Buffer.concat(chunks, maxBody)
-      cancelDownload(req, res)
-    }
-    res.on('data', onData)
+    keepFirstBytes(req, res, maxBody)
   })
 
   req.on('redirect', res => {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "standard-version": "latest"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=14"
   },
   "files": [
     "index.js"

--- a/test/index.js
+++ b/test/index.js
@@ -293,26 +293,30 @@ test('maxBody spans several chunks', async t => {
   t.is(res.body.toString(), 'abcd')
 })
 
-test('maxBody Infinity keeps the whole body', async t => {
-  const url = await createTestServer(t, (req, res) => sendPayload(res))
+test('maxBody leaves an entity that already fits', async t => {
+  const url = await createTestServer(t, (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain', 'content-length': 2 })
+    res.end('ab')
+  })
 
-  const res = await reachableUrl(url, { maxBody: Infinity })
+  const res = await reachableUrl(url, { maxBody: 64 })
 
-  t.is(res.statusCode, 200)
-  t.deepEqual(res.body, LARGE_PAYLOAD)
+  t.is(res.body.toString(), 'ab')
 })
 
-// Asking for one byte while wanting the entity would have a compliant server
-// answer 206 with that byte, so the range has to go.
-test('maxBody above the range drops the Range header', async t => {
+// Asking for one byte while wanting more would have a compliant server answer
+// 206 with that byte, so the range has to go.
+test('maxBody above the range keeps the whole body and drops the Range header', async t => {
   let range = 'unset'
   const url = await createTestServer(t, (req, res) => {
     range = req.headers.range
     sendPayload(res)
   })
 
-  await reachableUrl(url, { maxBody: Infinity })
+  const res = await reachableUrl(url, { maxBody: Infinity })
   t.is(range, undefined)
+  t.is(res.statusCode, 200)
+  t.deepEqual(res.body, LARGE_PAYLOAD)
 
   await reachableUrl(url)
   t.is(range, 'bytes=0-0')

--- a/test/index.js
+++ b/test/index.js
@@ -269,6 +269,71 @@ test('abort the download on a 413 got will not retry', async t => {
   t.is(res.body, undefined)
 })
 
+test('maxBody keeps the first bytes of an ignored Range', async t => {
+  const url = await createTestServer(t, (req, res) => sendPayload(res))
+
+  const res = await reachableUrl(url, { maxBody: 1 })
+
+  t.is(res.statusCode, 200)
+  t.is(res.body.length, 1)
+  t.is(res.body[0], LARGE_PAYLOAD[0])
+  // The whole point: the byte arrives without the entity behind it.
+  t.is(res.headers['content-length'], String(LARGE_PAYLOAD.length))
+})
+
+test('maxBody keeps as many bytes as asked', async t => {
+  const url = await createTestServer(t, (req, res) => sendPayload(res))
+
+  const res = await reachableUrl(url, { maxBody: 64 })
+
+  t.is(res.body.length, 64)
+  t.deepEqual(res.body, LARGE_PAYLOAD.subarray(0, 64))
+})
+
+test('maxBody spans several chunks', async t => {
+  const url = await createTestServer(t, (req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain', 'content-length': 6 })
+    res.write('ab')
+    setTimeout(() => res.write('cd'), 20)
+    setTimeout(() => res.end('ef'), 40)
+  })
+
+  const res = await reachableUrl(url, { maxBody: 4 })
+
+  t.is(res.body.toString(), 'abcd')
+})
+
+test('maxBody Infinity keeps the whole body', async t => {
+  const url = await createTestServer(t, (req, res) => sendPayload(res))
+
+  const res = await reachableUrl(url, { maxBody: Infinity })
+
+  t.is(res.statusCode, 200)
+  t.deepEqual(res.body, LARGE_PAYLOAD)
+})
+
+// Asking for one byte while wanting the entity would have a compliant server
+// answer 206 with that byte, so the range has to go.
+test('maxBody above the range drops the Range header', async t => {
+  let range = 'unset'
+  const url = await createTestServer(t, (req, res) => {
+    range = req.headers.range
+    sendPayload(res)
+  })
+
+  await reachableUrl(url, { maxBody: Infinity })
+  t.is(range, undefined)
+
+  await reachableUrl(url)
+  t.is(range, 'bytes=0-0')
+})
+
+test('maxBody is not forwarded to got', async t => {
+  const url = await createEchoServer(t)
+
+  await t.notThrowsAsync(reachableUrl(`${url}/`, { maxBody: 1 }))
+})
+
 test('reject an unpatched cacheable-request', t => {
   const error = t.throws(
     () => reachableUrl.assertCacheSupport(() => ({ name: 'cacheable-request' })),

--- a/test/index.js
+++ b/test/index.js
@@ -297,8 +297,9 @@ test('maxBody spans several chunks', async t => {
 // would take the process down instead of the promise.
 test('maxBody rejects a count Buffer cannot take', async t => {
   for (const maxBody of [-1, 0.5, '1', null, NaN]) {
-    const error = await t.throwsAsync(reachableUrl('https://example.com', { maxBody }))
-    t.is(error.constructor.name, 'TypeError')
+    await t.throwsAsync(reachableUrl('https://example.com', { maxBody }), {
+      instanceOf: TypeError
+    })
   }
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -272,22 +272,12 @@ test('abort the download on a 413 got will not retry', async t => {
 test('maxBody keeps the first bytes of an ignored Range', async t => {
   const url = await createTestServer(t, (req, res) => sendPayload(res))
 
-  const res = await reachableUrl(url, { maxBody: 1 })
-
-  t.is(res.statusCode, 200)
-  t.is(res.body.length, 1)
-  t.is(res.body[0], LARGE_PAYLOAD[0])
-  // The whole point: the byte arrives without the entity behind it.
-  t.is(res.headers['content-length'], String(LARGE_PAYLOAD.length))
-})
-
-test('maxBody keeps as many bytes as asked', async t => {
-  const url = await createTestServer(t, (req, res) => sendPayload(res))
-
   const res = await reachableUrl(url, { maxBody: 64 })
 
-  t.is(res.body.length, 64)
+  t.is(res.statusCode, 200)
   t.deepEqual(res.body, LARGE_PAYLOAD.subarray(0, 64))
+  // The whole point: the bytes arrive without the entity behind them.
+  t.is(res.headers['content-length'], String(LARGE_PAYLOAD.length))
 })
 
 test('maxBody spans several chunks', async t => {
@@ -326,12 +316,6 @@ test('maxBody above the range drops the Range header', async t => {
 
   await reachableUrl(url)
   t.is(range, 'bytes=0-0')
-})
-
-test('maxBody is not forwarded to got', async t => {
-  const url = await createEchoServer(t)
-
-  await t.notThrowsAsync(reachableUrl(`${url}/`, { maxBody: 1 }))
 })
 
 test('reject an unpatched cacheable-request', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -293,6 +293,15 @@ test('maxBody spans several chunks', async t => {
   t.is(res.body.toString(), 'abcd')
 })
 
+// The count reaches `Buffer.concat` inside a stream callback, where the throw
+// would take the process down instead of the promise.
+test('maxBody rejects a count Buffer cannot take', async t => {
+  for (const maxBody of [-1, 0.5, '1', null, NaN]) {
+    const error = await t.throwsAsync(reachableUrl('https://example.com', { maxBody }))
+    t.is(error.constructor.name, 'TypeError')
+  }
+})
+
 test('maxBody leaves an entity that already fits', async t => {
   const url = await createTestServer(t, (req, res) => {
     res.writeHead(200, { 'content-type': 'text/plain', 'content-length': 2 })

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,8 @@ const {
   createTestServer,
   createEchoServer,
   createStatusServer,
-  createRangeServer
+  createRangeServer,
+  createAssetServer
 } = require('./_helpers')
 
 const reachableUrl = require('..')
@@ -304,10 +305,7 @@ test('maxBody rejects a count Buffer cannot take', async t => {
 })
 
 test('maxBody leaves an entity that already fits', async t => {
-  const url = await createTestServer(t, (req, res) => {
-    res.writeHead(200, { 'content-type': 'text/plain', 'content-length': 2 })
-    res.end('ab')
-  })
+  const url = await createAssetServer(t, { body: 'ab' })
 
   const res = await reachableUrl(url, { maxBody: 64 })
 


### PR DESCRIPTION
## Problem

v2 cancels the download once the headers answer reachability, so `body` is `undefined`. Two consumers need bytes anyway, and today the only way to keep them is passing `cache` — asking for a cache you don't want, just to stop the abort.

**`metascraper-logo-favicon` needs one byte.** It probes guessed URLs (`/favicon.ico`, `/favicon.png`) that the site never declared, and plenty of servers answer 200 for every path with `index.html` while setting content-type from the requested extension. So the header says `image/png` and the bytes are HTML:

```js
// 60 is the ASCII code for '<'
if (contentTypes && (!response.body || response.body[0] === 60)) return undefined
```

Only `ico` and `png` are handled, both binary with fixed magic bytes (`00 00 01 00`, `89 50 4E 47`), so a leading `<` can only be markup. Without it, every SPA-hosted site would publish a logo URL that renders nothing.

Measured on v2: server honors `Range` → `body = 1 byte, [0] = '<'`, check works. Server ignores `Range` → `body = undefined`, favicon silently dropped, 0 of 20 runs kept the byte.

**`microlink/api` needs the whole body.** Its favicon wrapper runs `isXSS`, which loads the document into a DOM and executes its scripts — the vector is a `<script>` inside an SVG favicon. A prefix is not just insufficient there, it would be a bypass: pad to the cap, put the payload after it.

## Fix

```js
const { maxBody = 0 } = opts
```

| `maxBody` | Range sent | behavior | `body` |
|---|---|---|---|
| `0` (default) | `bytes=0-0` | cancel at headers | `undefined` |
| `1` | `bytes=0-0` | read 1 byte, cancel | 1 byte |
| `N` | `bytes=0-0` | read N, cancel | ≤ N |
| `Infinity` | **omitted** | never cancel | whole entity |

Dropping the `Range` header above one byte matters: asking for `bytes=0-0` while wanting everything would have a compliant server answer `206` with that single byte, and the caller would scan one character. It also lets a consumer stop hand-stripping the header.

`maxBody` is destructured out before the options reach got.

## Result

```
841 tests passed
All files |     100 |      100 |     100 |     100 |
```

Six new tests: first bytes of an ignored range, an exact byte count, a body spanning several chunks, `Infinity`, the `Range` header being dropped only above one byte, and `maxBody` not leaking into got.

Nothing changes by default — `maxBody` is `0`, so `ffprobe` and `get-media-meta` in microlink/api keep aborting at the headers.

## Follow-ups in other repos

- `metascraper-logo-favicon` → `maxBody: 1` in `defaultResolveFaviconUrl`
- `microlink/api` favicon wrapper → `maxBody: Infinity`, and its own `headers: { Range: undefined }` can go

Both are still on `reachable-url@1.8.3`. Bumping either to v2 before those land drops favicons silently, with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JDsM3McLV5LtR3rFd97Sb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default `maxBody: 0` preserves existing abort semantics; new paths are gated on explicit option values with upfront validation.
> 
> **Overview**
> Adds a **`maxBody`** option (default **`0`**) so callers can keep some or all of the response body when the library would otherwise cancel after headers—without relying on **`cache`** just to disable the abort.
> 
> With **`maxBody: 0`**, behavior is unchanged: cancel as soon as reachability is known and **`body`** stays **`undefined`** when the server ignores **`Range`**. For **`1 ≤ maxBody < Infinity`**, it buffers up to that many bytes from the stream, sets **`res.body`**, then cancels. For **`Infinity`**, downloads are not aborted for that reason (same idea as cache). Invalid values throw **`TypeError`** before the request starts.
> 
> When **`maxBody > 1`**, the default **`Range: bytes=0-0`** header is removed so a range-compliant server does not return only one byte. **`maxBody`** is stripped from options before they are passed to **got**.
> 
> README documents **`maxBody`** with examples; **`engines.node`** is bumped to **`>=14`**. Six tests cover partial bodies, multi-chunk reads, validation, small entities, and **`Range`** omission for **`Infinity`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47b76823e54e22abb91559ec022e4f79e33faf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->